### PR TITLE
feat(gea-tools): add go-to-definition and auto-import for JSX components

### DIFF
--- a/packages/gea-tools/README.md
+++ b/packages/gea-tools/README.md
@@ -13,6 +13,8 @@ The extension is focused on code intelligence, not custom syntax highlighting. I
 - Component completion inside JSX tags
 - Prop completion based on the target component's declared props
 - Event attribute completion for Gea JSX events like `click`, `input`, `change`, and `keydown`
+- Go to Definition for imported or workspace-discovered JSX components
+- Quick Fix auto-imports for unknown default-exported JSX components
 - Hover details for components, props, and event attributes
 - Unknown component warnings for JSX tags that look like Gea components
 - TypeScript plugin support for suppressing noisy JSX diagnostics and unused-import warnings for imported components used as JSX tags
@@ -98,6 +100,14 @@ export default function PaymentForm(props) {
   return <div />
 }
 ```
+
+### Go to Definition
+
+Place the cursor on a JSX component tag such as `<TodoItem />` and run Go to Definition to jump to the component declaration. The language server resolves both already-imported components and matching default-exported workspace components.
+
+### Quick Fix Auto Import
+
+If you reference a default-exported component before importing it, Gea Tools offers a Quick Fix to add the missing relative import. When multiple components share the same name, the closest matching file path is preferred.
 
 ### Event Completion
 

--- a/packages/gea-tools/TESTING.md
+++ b/packages/gea-tools/TESTING.md
@@ -37,6 +37,10 @@ vsce package
 - [ ] Typing inside `<PaymentForm ...>` suggests props discovered from `const { ... } = props`.
 - [ ] Event attribute completion suggests `click`, `input`, `change`, `keydown`, `blur`, and `submit`.
 - [ ] Hovering `TodoItem` shows component details and discovered props.
+- [ ] Go to Definition on an imported JSX component jumps to its declaration.
+- [ ] Quick Fix on an unknown JSX component adds the correct relative default import.
+- [ ] Quick Fix does not add a duplicate import if the component is already imported.
+- [ ] Quick Fix does not appear for HTML tags or built-in Gea Mobile tags.
 - [ ] Hovering an event attribute like `click` shows event help.
 - [ ] Unknown component diagnostics appear for invalid JSX component tags.
 - [ ] Imported components used as JSX tags do not show noisy unused-import diagnostics.
@@ -82,6 +86,24 @@ export default function PaymentForm(props) {
 ```
 
 Confirm `<PaymentForm ...>` offers those props.
+
+### Go to Definition
+
+Use a file that imports `TodoItem` and renders `<TodoItem ... />`.
+
+- Place the cursor on `TodoItem` in JSX.
+- Trigger Go to Definition.
+- Confirm the editor jumps to the `TodoItem` component declaration.
+
+### Auto import Quick Fix
+
+Temporarily remove the `TodoItem` import from a file that renders `<TodoItem ... />`.
+
+- Confirm the extension shows `Unknown component: TodoItem`.
+- Trigger Quick Fix on the diagnostic.
+- Confirm the correct `import TodoItem from '...'` line is inserted.
+- Trigger Quick Fix again and confirm no duplicate import is created.
+- Repeat with built-in tags such as `<view />` and confirm no import Quick Fix is offered.
 
 ## Troubleshooting
 

--- a/packages/gea-tools/src/component-discovery.ts
+++ b/packages/gea-tools/src/component-discovery.ts
@@ -7,19 +7,33 @@ export interface ComponentInfo {
   description?: string
   props?: string[]
   filePath?: string
+  declarationOffset?: number
+  exportKind?: 'default'
 }
 
 export class ComponentDiscovery {
   private components: Map<string, ComponentInfo> = new Map()
+  private workspaceRoots: string[] = []
+
+  setWorkspaceRoots(roots: string[]): void {
+    this.workspaceRoots = roots.map((root) => this.normalizeFilePath(root))
+  }
 
   scanWorkspace(): void {
-    // This would be called with workspace folders from LSP
-    // For now, we'll discover components on-demand from open files
+    this.components.clear()
+
+    for (const root of this.workspaceRoots) {
+      if (!fs.existsSync(root)) {
+        continue
+      }
+
+      this.scanDirectory(root)
+    }
   }
 
   discoverComponentsInFile(text: string, uri: string): ComponentInfo[] {
     const components: ComponentInfo[] = []
-    const filePath = uri.startsWith('file://') ? uri.substring(7) : uri
+    const filePath = this.normalizeFilePath(uri)
 
     const discovered = new Map<string, ComponentInfo>()
     this.discoverClassComponents(text, filePath, discovered)
@@ -31,22 +45,26 @@ export class ComponentDiscovery {
   }
 
   addComponents(components: ComponentInfo[]): void {
-    for (const comp of components) {
-      // Store by tagName (kebab-case)
-      this.components.set(comp.tagName, comp)
-      // Store by lowercase name
-      this.components.set(comp.name.toLowerCase(), comp)
-      // Store by exact name (PascalCase)
-      this.components.set(comp.name, comp)
+    for (const component of components) {
+      const merged = this.mergeComponent(component)
+      this.storeComponent(merged)
     }
   }
 
   getAllComponents(): ComponentInfo[] {
-    // Use a Set to avoid duplicates (same component stored under multiple keys)
     const uniqueComponents = new Map<string, ComponentInfo>()
-    for (const comp of this.components.values()) {
-      uniqueComponents.set(comp.name, comp)
+    for (const component of this.components.values()) {
+      const key = this.getComponentIdentity(component)
+      const existing = uniqueComponents.get(key)
+
+      if (!existing) {
+        uniqueComponents.set(key, component)
+        continue
+      }
+
+      uniqueComponents.set(key, this.preferRicherComponent(existing, component))
     }
+
     return Array.from(uniqueComponents.values())
   }
 
@@ -58,20 +76,47 @@ export class ComponentDiscovery {
     )
   }
 
+  getBestComponentMatch(tagName: string, fromFilePath?: string): ComponentInfo | undefined {
+    const normalizedFromFile = fromFilePath ? this.normalizeFilePath(fromFilePath) : undefined
+    const matches = this.getAllComponents().filter((component) => {
+      if (!component.filePath || component.exportKind !== 'default') {
+        return false
+      }
+
+      const lowerName = tagName.toLowerCase()
+      return component.name === tagName || component.name.toLowerCase() === lowerName || component.tagName === lowerName
+    })
+
+    if (matches.length === 0) {
+      return undefined
+    }
+
+    matches.sort((left, right) => {
+      const leftScore = this.getComponentDistanceScore(left, normalizedFromFile)
+      const rightScore = this.getComponentDistanceScore(right, normalizedFromFile)
+
+      if (leftScore !== rightScore) {
+        return leftScore - rightScore
+      }
+
+      const leftPath = left.filePath ?? ''
+      const rightPath = right.filePath ?? ''
+      return leftPath.localeCompare(rightPath)
+    })
+
+    return matches[0]
+  }
+
   discoverImportedComponents(text: string, currentUri: string): ComponentInfo[] {
     const components: ComponentInfo[] = []
-    let filePath = currentUri.startsWith('file://') ? currentUri.substring(7) : currentUri
-    if (filePath.startsWith('/') && process.platform !== 'win32') {
-      // Unix path, no transform needed
-    } else if (filePath.match(/^\/[A-Z]:/i)) {
-      filePath = filePath.substring(1)
-    }
+    const filePath = this.normalizeFilePath(currentUri)
     const dir = path.dirname(filePath)
 
     const defaultImportRegex = /import\s+(\w+)\s+from\s+['"]([^'"]+)['"]/g
-    let match
+    let match: RegExpExecArray | null
 
     while ((match = defaultImportRegex.exec(text)) !== null) {
+      const importName = match[1]
       const importPath = match[2]
 
       if (!importPath || (!importPath.startsWith('.') && !importPath.startsWith('/'))) {
@@ -88,20 +133,145 @@ export class ComponentDiscovery {
         const importedText = fs.readFileSync(resolvedPath, 'utf-8')
         const importedComponents = this.discoverComponentsInFile(importedText, `file://${resolvedPath}`)
 
+        const matchedComponent = importedComponents.find((component) => component.name === importName)
+        if (matchedComponent) {
+          components.push(matchedComponent)
+          continue
+        }
+
         if (importedComponents.length > 0) {
           components.push(...importedComponents)
         }
-      } catch (error) {
-        if (error instanceof Error) {
-          if (!error.message.includes('ENOENT')) {
-            console.error(`Error discovering components from ${importPath}:`, error.message)
-          }
+      } catch (error: unknown) {
+        if (error instanceof Error && !error.message.includes('ENOENT')) {
+          console.error(`Error discovering components from ${importPath}:`, error.message)
         }
-        continue
       }
     }
 
     return components
+  }
+
+  toRelativeImportPath(fromFilePath: string, targetFilePath: string): string {
+    const normalizedFromFile = this.normalizeFilePath(fromFilePath)
+    const normalizedTargetFile = this.normalizeFilePath(targetFilePath)
+    const fromDir = path.dirname(normalizedFromFile)
+
+    let relativePath = path.relative(fromDir, normalizedTargetFile).replace(/\\/g, '/')
+    relativePath = relativePath.replace(/\.(?:jsx?|tsx?)$/, '')
+
+    if (relativePath.endsWith('/index')) {
+      relativePath = relativePath.slice(0, -'/index'.length)
+    }
+
+    if (!relativePath.startsWith('.')) {
+      relativePath = `./${relativePath}`
+    }
+
+    return relativePath
+  }
+
+  private scanDirectory(dir: string): void {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name)
+      if (this.shouldIgnorePath(entryPath)) {
+        continue
+      }
+
+      if (entry.isDirectory()) {
+        this.scanDirectory(entryPath)
+        continue
+      }
+
+      if (!this.isSupportedSourceFile(entryPath)) {
+        continue
+      }
+
+      try {
+        const text = fs.readFileSync(entryPath, 'utf-8')
+        const components = this.discoverComponentsInFile(text, `file://${entryPath}`)
+        this.addComponents(components)
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          console.error(`Error scanning ${entryPath}:`, error.message)
+        }
+      }
+    }
+  }
+
+  private shouldIgnorePath(filePath: string): boolean {
+    const normalizedPath = this.normalizeFilePath(filePath)
+    const segments = normalizedPath.split(/[\\/]+/)
+    return segments.some((segment) => ['.git', 'dist', 'node_modules', 'out', 'website'].includes(segment))
+  }
+
+  private isSupportedSourceFile(filePath: string): boolean {
+    return /\.(?:js|jsx|ts|tsx)$/.test(filePath)
+  }
+
+  private getComponentDistanceScore(component: ComponentInfo, fromFilePath?: string): number {
+    if (!fromFilePath || !component.filePath) {
+      return Number.MAX_SAFE_INTEGER
+    }
+
+    const relativePath = this.toRelativeImportPath(fromFilePath, component.filePath)
+    return relativePath.split('/').length
+  }
+
+  private mergeComponent(component: ComponentInfo): ComponentInfo {
+    const existing = component.filePath ? this.findExistingComponent(component) : undefined
+    if (!existing) {
+      return component
+    }
+
+    return this.preferRicherComponent(existing, component)
+  }
+
+  private findExistingComponent(component: ComponentInfo): ComponentInfo | undefined {
+    const existingCandidates = [
+      this.components.get(component.name),
+      this.components.get(component.name.toLowerCase()),
+      this.components.get(component.tagName),
+    ]
+
+    return existingCandidates.find((candidate) => candidate?.filePath === component.filePath)
+  }
+
+  private preferRicherComponent(left: ComponentInfo, right: ComponentInfo): ComponentInfo {
+    const leftScore = this.getComponentRichness(left)
+    const rightScore = this.getComponentRichness(right)
+    return rightScore >= leftScore ? { ...left, ...right } : { ...right, ...left }
+  }
+
+  private getComponentRichness(component: ComponentInfo): number {
+    return [component.description, component.filePath, component.declarationOffset, component.props?.length].filter(
+      (value) => value !== undefined,
+    ).length
+  }
+
+  private storeComponent(component: ComponentInfo): void {
+    this.components.set(component.tagName, component)
+    this.components.set(component.name.toLowerCase(), component)
+    this.components.set(component.name, component)
+  }
+
+  private getComponentIdentity(component: ComponentInfo): string {
+    return `${component.filePath ?? ''}:${component.name}`
+  }
+
+  private normalizeFilePath(uriOrPath: string): string {
+    let filePath = decodeURIComponent(uriOrPath)
+    if (filePath.startsWith('file://')) {
+      filePath = filePath.slice('file://'.length)
+    }
+
+    if (filePath.match(/^\/[A-Z]:/i)) {
+      filePath = filePath.slice(1)
+    }
+
+    return path.normalize(filePath)
   }
 
   private toPascalCase(str: string): string {
@@ -116,6 +286,7 @@ export class ComponentDiscovery {
     let match: RegExpExecArray | null
 
     while ((match = classRegex.exec(text)) !== null) {
+      const isDefaultExport = Boolean(match[1])
       const className = match[2]
       const classStart = match.index
       const classBody = text.slice(classStart)
@@ -128,6 +299,8 @@ export class ComponentDiscovery {
         description,
         props,
         filePath,
+        declarationOffset: classStart,
+        exportKind: isDefaultExport ? 'default' : undefined,
       })
     }
   }
@@ -137,6 +310,7 @@ export class ComponentDiscovery {
     let match: RegExpExecArray | null
 
     while ((match = functionRegex.exec(text)) !== null) {
+      const isDefaultExport = Boolean(match[1])
       const name = match[2]
       const params = match[3]
       const functionStart = match.index
@@ -150,6 +324,8 @@ export class ComponentDiscovery {
         description,
         props,
         filePath,
+        declarationOffset: functionStart,
+        exportKind: isDefaultExport ? 'default' : undefined,
       })
     }
   }
@@ -325,11 +501,9 @@ export class ComponentDiscovery {
   }
 
   private extractDescription(text: string, className: string): string | undefined {
-    // Look for JSDoc comment before the class
     const classIndex = text.indexOf(`class ${className}`)
     if (classIndex === -1) return undefined
 
-    // Look backwards for JSDoc
     const beforeClass = text.substring(Math.max(0, classIndex - 500), classIndex)
     const jsdocMatch = beforeClass.match(/\*\s*([^\n]+)/)
 

--- a/packages/gea-tools/src/server.ts
+++ b/packages/gea-tools/src/server.ts
@@ -1,19 +1,29 @@
+import * as fs from 'fs'
+import { pathToFileURL } from 'url'
 import {
+  CodeAction,
+  CodeActionKind,
+  CodeActionParams,
   CompletionItem,
   CompletionItemKind,
   createConnection,
   Diagnostic,
   DiagnosticSeverity,
+  Definition,
+  DefinitionParams,
   DidChangeConfigurationNotification,
   Hover,
   InitializeParams,
   InitializeResult,
+  Location,
   MarkupKind,
+  Position,
   ProposedFeatures,
   Range,
   TextDocumentPositionParams,
   TextDocumentSyncKind,
   TextDocuments,
+  WorkspaceEdit,
 } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { ComponentDiscovery, type ComponentInfo } from './component-discovery'
@@ -30,6 +40,11 @@ interface OpenTagContext {
   source: string
   sourceBeforeCursor: string
   tagName: string
+}
+
+interface ComponentMatchContext {
+  component?: ComponentInfo
+  context: OpenTagContext
 }
 
 const connection = createConnection(ProposedFeatures.all)
@@ -72,6 +87,7 @@ const EVENT_TYPES = [
 ]
 
 const COMMON_COMPONENT_PROPS = ['key', 'class', 'className', 'style', 'id']
+const UNKNOWN_COMPONENT_CODE = 'gea.unknownComponent'
 
 const HTML_ELEMENTS = new Set([
   'a',
@@ -124,6 +140,12 @@ const HTML_ELEMENTS = new Set([
 connection.onInitialize((params: InitializeParams) => {
   const capabilities = params.capabilities
 
+  const workspaceRoots = [
+    ...(params.workspaceFolders?.map((folder) => folder.uri) ?? []),
+    ...(params.rootUri ? [params.rootUri] : []),
+  ]
+  componentDiscovery.setWorkspaceRoots(Array.from(new Set(workspaceRoots)))
+
   hasConfigurationCapability = !!capabilities.workspace?.configuration
   hasWorkspaceFolderCapability = !!capabilities.workspace?.workspaceFolders
 
@@ -134,6 +156,8 @@ connection.onInitialize((params: InitializeParams) => {
         resolveProvider: false,
         triggerCharacters: ['<', ' '],
       },
+      codeActionProvider: true,
+      definitionProvider: true,
       hoverProvider: true,
     },
   }
@@ -155,7 +179,9 @@ connection.onInitialized(() => {
   }
 
   if (hasWorkspaceFolderCapability) {
-    connection.workspace.onDidChangeWorkspaceFolders(() => {
+    connection.workspace.onDidChangeWorkspaceFolders(async () => {
+      const workspaceFolders = await connection.workspace.getWorkspaceFolders()
+      componentDiscovery.setWorkspaceRoots(workspaceFolders?.map((folder) => folder.uri) ?? [])
       componentDiscovery.scanWorkspace()
     })
   }
@@ -212,6 +238,7 @@ async function validateTextDocument(textDocument: TextDocument): Promise<void> {
     const component = findComponent(components, tag.name)
     if (!component) {
       diagnostics.push({
+        code: UNKNOWN_COMPONENT_CODE,
         severity: DiagnosticSeverity.Warning,
         range: Range.create(textDocument.positionAt(tag.start), textDocument.positionAt(tag.end)),
         message: `Unknown component: ${tag.name}`,
@@ -429,6 +456,167 @@ function buildEventCompletion(eventName: string): CompletionItem {
   }
 }
 
+function getDocumentFilePath(uri: string): string {
+  let filePath = decodeURIComponent(uri)
+  if (filePath.startsWith('file://')) {
+    filePath = filePath.slice('file://'.length)
+  }
+
+  if (filePath.match(/^\/[A-Z]:/i)) {
+    filePath = filePath.slice(1)
+  }
+
+  return filePath
+}
+
+function getComponentAtPosition(document: TextDocument, position: Position): ComponentMatchContext | null {
+  const text = document.getText()
+  const offset = document.offsetAt(position)
+  const context = getOpenTagContext(text, offset)
+  if (!context) {
+    return null
+  }
+
+  const components = getAllComponents(text, document.uri)
+  return {
+    component: findComponent(components, context.tagName),
+    context,
+  }
+}
+
+function isCursorOnTagName(context: OpenTagContext, offset: number): boolean {
+  const tagNameStart = context.start + 1
+  const tagNameEnd = tagNameStart + context.tagName.length
+  return offset >= tagNameStart && offset <= tagNameEnd
+}
+
+function createDefinitionLocation(document: TextDocument, component: ComponentInfo): Location | null {
+  if (!component.filePath) {
+    return null
+  }
+
+  const targetUri = pathToFileURL(component.filePath).toString()
+  const offset = component.declarationOffset ?? 0
+  const currentFilePath = getDocumentFilePath(document.uri)
+  const position =
+    component.filePath === currentFilePath
+      ? document.positionAt(offset)
+      : getPositionFromFile(component.filePath, offset)
+
+  return Location.create(targetUri, Range.create(position, position))
+}
+
+function getPositionFromFile(filePath: string, offset: number): Position {
+  try {
+    const text = fs.readFileSync(filePath, 'utf8')
+    const boundedOffset = Math.max(0, Math.min(offset, text.length))
+    const prefix = text.slice(0, boundedOffset)
+    const lines = prefix.split(/\r?\n/)
+    return Position.create(lines.length - 1, lines[lines.length - 1]?.length ?? 0)
+  } catch {
+    return Position.create(0, 0)
+  }
+}
+
+function extractUnknownComponentName(diagnostic: Diagnostic): string | null {
+  if (diagnostic.code !== UNKNOWN_COMPONENT_CODE) {
+    return null
+  }
+
+  const match = diagnostic.message.match(/^Unknown component: (.+)$/)
+  return match ? match[1] : null
+}
+
+function hasImportForComponent(text: string, component: ComponentInfo): boolean {
+  const importRegex = new RegExp(`import\\s+${component.name}\\b`)
+  return importRegex.test(text)
+}
+
+function findImportInsertionOffset(text: string): number {
+  const lines = text.split(/\r?\n/)
+  let offset = 0
+  let lastImportOffset = 0
+  let lastLeadingOffset = 0
+  let collectingImport = false
+
+  for (const line of lines) {
+    const lineLength = line.length + 1
+    const trimmed = line.trim()
+
+    if (!collectingImport) {
+      if (!trimmed || trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*')) {
+        offset += lineLength
+        lastLeadingOffset = offset
+        continue
+      }
+
+      if (!trimmed.startsWith('import ')) {
+        break
+      }
+
+      collectingImport = true
+    }
+
+    offset += lineLength
+
+    if (trimmed.endsWith(';') || /from\s+['"][^'"]+['"]$/.test(trimmed) || /^import\s+['"][^'"]+['"]$/.test(trimmed)) {
+      collectingImport = false
+      lastImportOffset = offset
+    }
+  }
+
+  return lastImportOffset || lastLeadingOffset
+}
+
+function buildImportText(document: TextDocument, component: ComponentInfo): string | null {
+  if (!component.filePath) {
+    return null
+  }
+
+  const currentFilePath = getDocumentFilePath(document.uri)
+  const importPath = componentDiscovery.toRelativeImportPath(currentFilePath, component.filePath)
+  return `import ${component.name} from '${importPath}'\n`
+}
+
+function buildUnknownComponentCodeAction(document: TextDocument, diagnostic: Diagnostic): CodeAction | null {
+  const componentName = extractUnknownComponentName(diagnostic)
+  if (!componentName) {
+    return null
+  }
+
+  const text = document.getText()
+  const currentFilePath = getDocumentFilePath(document.uri)
+  const component = componentDiscovery.getBestComponentMatch(componentName, currentFilePath)
+  if (!component || hasImportForComponent(text, component)) {
+    return null
+  }
+
+  const importText = buildImportText(document, component)
+  if (!importText) {
+    return null
+  }
+
+  const insertionOffset = findImportInsertionOffset(text)
+  const insertionPosition = document.positionAt(insertionOffset)
+  const edit: WorkspaceEdit = {
+    changes: {
+      [document.uri]: [
+        {
+          newText: importText,
+          range: Range.create(insertionPosition, insertionPosition),
+        },
+      ],
+    },
+  }
+
+  return {
+    diagnostics: [diagnostic],
+    edit,
+    kind: CodeActionKind.QuickFix,
+    title: `Add import for ${component.name}`,
+  }
+}
+
 connection.onCompletion((params: TextDocumentPositionParams): CompletionItem[] => {
   const document = documents.get(params.textDocument.uri)
   if (!document) {
@@ -472,6 +660,45 @@ connection.onCompletion((params: TextDocumentPositionParams): CompletionItem[] =
   }
 
   return results
+})
+
+connection.onDefinition((params: DefinitionParams): Definition | null => {
+  const document = documents.get(params.textDocument.uri)
+  if (!document) {
+    return null
+  }
+
+  const componentContext = getComponentAtPosition(document, params.position)
+  if (!componentContext) {
+    return null
+  }
+
+  const offset = document.offsetAt(params.position)
+  if (!isCursorOnTagName(componentContext.context, offset)) {
+    return null
+  }
+
+  const currentFilePath = getDocumentFilePath(document.uri)
+  const component =
+    componentContext.component ??
+    componentDiscovery.getBestComponentMatch(componentContext.context.tagName, currentFilePath)
+
+  if (!component) {
+    return null
+  }
+
+  return createDefinitionLocation(document, component)
+})
+
+connection.onCodeAction((params: CodeActionParams): CodeAction[] => {
+  const document = documents.get(params.textDocument.uri)
+  if (!document) {
+    return []
+  }
+
+  return params.context.diagnostics
+    .map((diagnostic) => buildUnknownComponentCodeAction(document, diagnostic))
+    .filter((action): action is CodeAction => action !== null)
 })
 
 connection.onRequest('textDocument/diagnostic', () => {


### PR DESCRIPTION
## What this does
This improves the JSX editing experience in `gea-tools`.
It adds Go to Definition for JSX component tags and a Quick Fix for missing imports when a default-exported component is used before being imported.
To support that, the component discovery logic now scans the workspace and keeps enough metadata to resolve declarations and generate relative import paths.
## Why
`gea-tools` already provides completions and hover information, but two common editing actions were still missing:
- jumping from a JSX tag to the component definition
- fixing a missing component import without doing it manually
This makes the extension more useful during regular development and reduces friction when working across multiple components.
## Notes
- auto-import currently supports default exports
- when multiple matching components exist, the closest relative path is preferred
- HTML tags and Gea built-in tags are excluded from import fixes
## Validation
- ran `npm run compile` in `packages/gea-tools`
- updated `packages/gea-tools/README.md`
- updated `packages/gea-tools/TESTING.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Go to Definition" for JSX components - quickly navigate to component declarations for both imported and workspace-discovered components
  * "Quick Fix Auto Import" - automatically inserts missing relative imports for referenced JSX components, with intelligent resolution when multiple components share the same name

* **Documentation**
  * Updated README documenting new language server capabilities
  * Enhanced testing documentation with manual test procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->