### PR TITLE
feat(vitepress): add plugin to move llms.txt files to parent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ docs/.vitepress/dist
 docs/.vitepress/cache
 docs/public/gea-ui-showcase
 website/docs
+website/llms*.txt
 .worktrees

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vitepress'
 import llmstxt, { copyOrDownloadAsMarkdownButtons } from 'vitepress-plugin-llms'
+import { moveLlmsTxtToOutDirParent } from './move-llms-txt-to-outdir-parent'
 
 export default defineConfig({
   vite: {
-    plugins: [llmstxt() as any],
+    plugins: [...(llmstxt() as any[]), moveLlmsTxtToOutDirParent() as any],
   },
   markdown: {
     config(md) {
@@ -12,7 +13,7 @@ export default defineConfig({
   },
   title: 'Gea',
   description: 'A lightweight, reactive JavaScript UI framework with compile-time JSX and proxy-based stores.',
-  base: '/docs/',
+  base: '/docs',
   outDir: '../website/docs',
   head: [
     [

--- a/docs/.vitepress/move-llms-txt-to-outdir-parent.ts
+++ b/docs/.vitepress/move-llms-txt-to-outdir-parent.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+/**
+ * vitepress-plugin-llms always emits llms.txt / llms-full.txt into VitePress outDir.
+ * Move those two files to the parent folder (e.g. website/ next to website/docs/).
+ * Per-page *.md copies stay in outDir so URLs under `base` stay correct.
+ */
+export function moveLlmsTxtToOutDirParent() {
+  let outDir: string | undefined
+  let isSsrBuild = false
+  return {
+    name: 'move-llms-txt-to-outdir-parent',
+    apply: 'build' as const,
+    enforce: 'post' as const,
+    configResolved(resolved: { build: { ssr?: boolean }; vitepress?: { outDir?: string } }) {
+      outDir = resolved.vitepress?.outDir
+      isSsrBuild = Boolean(resolved.build.ssr)
+    },
+    async closeBundle() {
+      if (isSsrBuild || !outDir) return
+      const parent = path.dirname(path.resolve(outDir))
+      for (const name of ['llms.txt', 'llms-full.txt'] as const) {
+        const from = path.join(outDir, name)
+        const to = path.join(parent, name)
+        try {
+          await fs.rename(from, to)
+        } catch (e: unknown) {
+          if ((e as NodeJS.ErrnoException).code !== 'ENOENT') throw e
+        }
+      }
+    },
+  }
+}


### PR DESCRIPTION
Introduced a new plugin that moves llms.txt and llms-full.txt files generated by vitepress-plugin-llms to the parent directory of the output folder. Updated the VitePress configuration to include this new plugin and adjusted the base path for the documentation output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated documentation site configuration and base path settings for improved URL routing.
  * Enhanced the build process with better handling of documentation artifacts during deployment.
  * Added version control exclusions for generated documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->