### PR TITLE
fix(docs): fix ui showcase on prod

### DIFF
--- a/docs/gea-ui/overview.md
+++ b/docs/gea-ui/overview.md
@@ -8,7 +8,7 @@
 npm install @geajs/ui
 ```
 
-`@geajs/ui` has a peer dependency on `@geajs/core` ^1.0.0. It also requires [Tailwind CSS](https://tailwindcss.com/) **v3** for styling — see [Getting Started](getting-started.md) for the full setup instructions.
+`@geajs/ui` has a peer dependency on `@geajs/core` ^1.0.0. It also requires [Tailwind CSS](https://tailwindcss.com/) for styling — see [Getting Started](getting-started.md) for the full setup instructions.
 
 ## Quick Example
 

--- a/examples/docs/app.tsx
+++ b/examples/docs/app.tsx
@@ -62,7 +62,7 @@ export default class App extends Component {
       <div class="docs-layout">
         <nav class="docs-sidebar">
           <div class="docs-sidebar-logo">gea-ui</div>
-          <div class="docs-sidebar-version">v0.1.0</div>
+          <div class="docs-sidebar-version">v0.2.0</div>
 
           <h4>General</h4>
           <a href="#button">Button</a>
@@ -2775,7 +2775,7 @@ ToastStore.loading({ title: 'Loading...', description: 'Wait.' })`}</div>
               padding: '2rem 0',
             }}
           >
-            gea-ui v0.1.0 — 35 components, fully accessible, keyboard navigable, and screen reader friendly.
+            gea-ui v0.2.0 — 35 components, fully accessible, keyboard navigable, and screen reader friendly.
           </p>
         </main>
         <Toaster />

--- a/examples/docs/vite.config.prod.ts
+++ b/examples/docs/vite.config.prod.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'vite'
-import { geaViteAliases } from '../shared/vite-config-base'
+import { geaUiDevSourcePlugin, geaViteAliases } from '../shared/vite-config-base'
 import tailwindcss from '@tailwindcss/vite'
 import { geaPlugin } from '../../packages/vite-plugin-gea/src/index.ts'
 
@@ -11,6 +11,7 @@ export default defineConfig({
   root: __dirname,
   base: '/docs/gea-ui-showcase/',
   plugins: [
+    geaUiDevSourcePlugin(),
     geaPlugin(),
     tailwindcss(),
   ],

--- a/tests/e2e/docs.spec.ts
+++ b/tests/e2e/docs.spec.ts
@@ -8,7 +8,7 @@ test.describe('docs component documentation', () => {
 
   test('renders sidebar with logo and version', async ({ page }) => {
     await expect(page.locator('.docs-sidebar-logo')).toHaveText('gea-ui')
-    await expect(page.locator('.docs-sidebar-version')).toContainText('v0.1.0')
+    await expect(page.locator('.docs-sidebar-version')).toContainText('v0.2.0')
   })
 
   test('sidebar has categorized navigation links', async ({ page }) => {


### PR DESCRIPTION
### Summary

Fixes UI Component Showcase on prod after Tailwind upgrade (sorry for that).
Changes UI version to 0.2.0 in the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Removed explicit Tailwind v3 pin from installation guidance.

* **Chores**
  * Updated displayed UI version to v0.2.0 across the docs site.
  * Added a development source plugin to the production build pipeline.
  * Updated end-to-end tests to expect the new version label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->