### PR TITLE
Fix Zag binding test loader

### DIFF
--- a/packages/gea-ui/tests/zag-bindings.test.ts
+++ b/packages/gea-ui/tests/zag-bindings.test.ts
@@ -90,6 +90,11 @@ async function flushMicrotasks(rounds = 20) {
 
 // ── Compilation helpers ──────────────────────────────────────────────────
 
+async function loadGeaCoreBindings() {
+  const { default: _default, ...coreBindings } = await import('../../gea/src/index')
+  return coreBindings
+}
+
 async function compileSource(source: string, id: string, className: string, bindings: Record<string, unknown>) {
   const plugin = geaPlugin()
   const transform = typeof plugin.transform === 'function' ? plugin.transform : plugin.transform?.handler
@@ -107,7 +112,8 @@ async function compileSource(source: string, id: string, className: string, bind
 return ${className};`
 
   try {
-    return new Function(...Object.keys(bindings), compiledSource)(...Object.values(bindings))
+    const runtimeBindings = { ...(await loadGeaCoreBindings()), ...bindings }
+    return new Function(...Object.keys(runtimeBindings), compiledSource)(...Object.values(runtimeBindings))
   } catch (e) {
     console.error(`\n=== COMPILATION ERROR for ${id} ===\n${compiledSource.substring(0, 2000)}\n===END===\n`)
     throw e
@@ -134,13 +140,23 @@ function transpileTs(source: string): string {
 
 async function loadZagComponent(Component: any) {
   const { VanillaMachine, normalizeProps, spreadProps } = await import('@zag-js/vanilla')
+  const { GEA_MAPS, GEA_SYNC_MAP, GEA_UPDATE_PROPS } = await import('../../gea/src/lib/symbols')
   const src = await readFile(resolve(__dirname, '../src/primitives/zag-component.ts'), 'utf-8')
   const js = transpileTs(src)
     .replace(/^import\b.*$/gm, '')
     .replace(/^export\s+default\s+class\s+/, 'class ')
     .replace(/^export\s*\{[\s\S]*?\};?\s*$/gm, '')
-  const fn = new Function('Component', 'VanillaMachine', 'normalizeProps', 'spreadProps', `${js}\nreturn ZagComponent;`)
-  return fn(Component, VanillaMachine, normalizeProps, spreadProps)
+  const fn = new Function(
+    'Component',
+    'VanillaMachine',
+    'normalizeProps',
+    'spreadProps',
+    'GEA_MAPS',
+    'GEA_SYNC_MAP',
+    'GEA_UPDATE_PROPS',
+    `${js}\nreturn ZagComponent;`,
+  )
+  return fn(Component, VanillaMachine, normalizeProps, spreadProps, GEA_MAPS, GEA_SYNC_MAP, GEA_UPDATE_PROPS)
 }
 
 async function loadRealComponent(fileName: string, className: string, ZagComponent: any, zagModule: any) {


### PR DESCRIPTION
## Summary

- Inject local Gea core bindings into the gea-ui Zag binding test loader
- Provide the Gea symbol keys needed when `ZagComponent` is evaluated manually
- Keep the existing source-transform test structure intact

## Why

The Zag binding tests strip import statements before evaluating transformed component source with `new Function(...)`. Current Gea internals use symbol-based runtime keys, so the manual evaluation scope needs those bindings just like normal module loading would provide them.

See also: #67

## Verification

```bash
npx tsx --test packages/gea-ui/tests/zag-bindings.test.ts
```

Result: 8/8 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for component binding and symbol loading by implementing dynamic import patterns and improved runtime binding resolution.

* **Refactor**
  * Optimized internal symbol management to better handle dynamic component evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->